### PR TITLE
Implement basis of rectangle division (1)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,17 @@
+[registries.crates-io]
+# The sparse protocol is currently planned to become the default for crates.io in the 1.70.0 release in a few months.
+protocol = "sparse"
+
+[target.'cfg(all())']
+rustflags = [
+    "-Wclippy::fallible_impl_from",
+    "-Dclippy::unwrap_used",
+    "-Dclippy::expect_used",
+]
+
+[alias]
+format = "fmt --all"
+format-check = "fmt --all -- --check"
+lint = "clippy --all-targets --all-features -- -D warnings"
+lint-fix = "clippy --all-targets --all-features --fix --allow-dirty --allow-staged"
+coverage = "llvm-cov --no-clean --lcov --output-path coverage.lcov"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml"
+    ]
+}

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -1,6 +1,8 @@
+use crate::dividing::Dividing;
 use crate::point::Point;
 use crate::rectangle::{Area, Rectangle};
 use crate::rotate::Rotate;
+
 /// axis aligned starting at x, y and ending at x + width, y + height (left to right, top to bottom)
 pub struct AxisAlignedRectangle<T> {
     pub point: Point<T>,
@@ -10,7 +12,7 @@ pub struct AxisAlignedRectangle<T> {
 /// A rectangle in 2D space constructor
 impl<T> AxisAlignedRectangle<T> {
     pub fn new(point: Point<T>, rectangle: Rectangle<T>) -> Self {
-        AxisAlignedRectangle { point, rectangle }
+        Self { point, rectangle }
     }
 }
 
@@ -22,12 +24,44 @@ impl<T: std::ops::Mul<Output = T> + Copy> Area<T> for AxisAlignedRectangle<T> {
 }
 
 /// Rotate an axis aligned rectangle by 90 degrees
-impl Rotate for AxisAlignedRectangle<i32> {
+impl<T: Copy> Rotate for AxisAlignedRectangle<T> {
     fn rotate(&self) -> Self {
-        AxisAlignedRectangle {
+        Self {
             point: self.point.rotate(),
             rectangle: self.rectangle.rotate(),
         }
+    }
+}
+
+impl<T: std::ops::Sub<Output = T> + std::ops::Add<Output = T> + Copy> Dividing<T>
+    for AxisAlignedRectangle<T>
+{
+    /// dividing a rectangle into two rectangles (vertical)
+    fn divide_vertical(&self, x: T) -> (AxisAlignedRectangle<T>, AxisAlignedRectangle<T>) {
+        (
+            Self::new(
+                Point::new(self.point.x, self.point.y),
+                Rectangle::new(x, self.rectangle.height),
+            ),
+            Self::new(
+                Point::new(self.point.x + x, self.point.y),
+                Rectangle::new(self.rectangle.width - x, self.rectangle.height),
+            ),
+        )
+    }
+
+    /// dividing a rectangle into two rectangles (horizontal)
+    fn divide_horizontal(&self, y: T) -> (AxisAlignedRectangle<T>, AxisAlignedRectangle<T>) {
+        (
+            Self::new(
+                Point::new(self.point.x, self.point.y),
+                Rectangle::new(self.rectangle.width, y),
+            ),
+            Self::new(
+                Point::new(self.point.x, self.point.y + y),
+                Rectangle::new(self.rectangle.width, self.rectangle.height - y),
+            ),
+        )
     }
 }
 
@@ -63,5 +97,35 @@ mod tests {
         let rect = Rectangle::new(4, 5);
         let result = AxisAlignedRectangle::new(point, rect).area();
         assert_eq!(result, 20);
+    }
+
+    #[test]
+    fn test_divide_vertical() {
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(4, 5);
+        let (rect_a, rect_b) = AxisAlignedRectangle::new(point, rect).divide_vertical(2);
+        assert_eq!(rect_a.point.x, 2);
+        assert_eq!(rect_a.point.y, 3);
+        assert_eq!(rect_a.rectangle.width, 2);
+        assert_eq!(rect_a.rectangle.height, 5);
+        assert_eq!(rect_b.point.x, 4);
+        assert_eq!(rect_b.point.y, 3);
+        assert_eq!(rect_b.rectangle.width, 2);
+        assert_eq!(rect_b.rectangle.height, 5);
+    }
+
+    #[test]
+    fn test_divide_horizontal() {
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(4, 5);
+        let (rect_a, rect_b) = AxisAlignedRectangle::new(point, rect).divide_horizontal(2);
+        assert_eq!(rect_a.point.x, 2);
+        assert_eq!(rect_a.point.y, 3);
+        assert_eq!(rect_a.rectangle.width, 4);
+        assert_eq!(rect_a.rectangle.height, 2);
+        assert_eq!(rect_b.point.x, 2);
+        assert_eq!(rect_b.point.y, 5);
+        assert_eq!(rect_b.rectangle.width, 4);
+        assert_eq!(rect_b.rectangle.height, 3);
     }
 }

--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -1,0 +1,67 @@
+use crate::point::Point;
+use crate::rectangle::{Area, Rectangle};
+use crate::rotate::Rotate;
+/// axis aligned starting at x, y and ending at x + width, y + height (left to right, top to bottom)
+pub struct AxisAlignedRectangle<T> {
+    pub point: Point<T>,
+    pub rectangle: Rectangle<T>,
+}
+
+/// A rectangle in 2D space constructor
+impl<T> AxisAlignedRectangle<T> {
+    pub fn new(point: Point<T>, rectangle: Rectangle<T>) -> Self {
+        AxisAlignedRectangle { point, rectangle }
+    }
+}
+
+/// area of an axis aligned rectangle
+impl<T: std::ops::Mul<Output = T> + Copy> Area<T> for AxisAlignedRectangle<T> {
+    fn area(&self) -> T {
+        self.rectangle.area()
+    }
+}
+
+/// Rotate an axis aligned rectangle by 90 degrees
+impl Rotate for AxisAlignedRectangle<i32> {
+    fn rotate(&self) -> Self {
+        AxisAlignedRectangle {
+            point: self.point.rotate(),
+            rectangle: self.rectangle.rotate(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(4, 5);
+        let result = AxisAlignedRectangle::new(point, rect);
+        assert_eq!(result.point.x, 2);
+        assert_eq!(result.point.y, 3);
+        assert_eq!(result.rectangle.width, 4);
+        assert_eq!(result.rectangle.height, 5);
+    }
+
+    #[test]
+    fn test_rotate() {
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(4, 5);
+        let result = AxisAlignedRectangle::new(point, rect).rotate();
+        assert_eq!(result.point.x, 3);
+        assert_eq!(result.point.y, 2);
+        assert_eq!(result.rectangle.width, 5);
+        assert_eq!(result.rectangle.height, 4);
+    }
+
+    #[test]
+    fn test_area() {
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(4, 5);
+        let result = AxisAlignedRectangle::new(point, rect).area();
+        assert_eq!(result, 20);
+    }
+}

--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -1,16 +1,61 @@
+use crate::component::Component;
 use crate::dividing::Dividing;
 use crate::point::Point;
-use crate::rectangle::{Area, Rectangle};
+use crate::rectangle::{Area, Rectangle, RectangleSize};
 use crate::rotate::Rotate;
 
 /// axis aligned starting at x, y and ending at x + width, y + height (left to right, top to bottom)
-pub struct AxisAlignedRectangle<T> {
+pub struct AxisAlignedRectangle<T>
+where
+    T: Copy,
+{
     pub point: Point<T>,
     pub rectangle: Rectangle<T>,
 }
 
+impl<T> Clone for AxisAlignedRectangle<T>
+where
+    T: Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            point: self.point.clone(),
+            rectangle: self.rectangle.clone(),
+        }
+    }
+}
+
+/// A rectangle in 2D space with a width and height
+impl<T> RectangleSize<T> for AxisAlignedRectangle<T>
+where
+    T: Copy,
+{
+    fn width(&self) -> T {
+        self.rectangle.width()
+    }
+    fn height(&self) -> T {
+        self.rectangle.height()
+    }
+}
+
+impl<T> Component<T> for AxisAlignedRectangle<T>
+where
+    T: Copy,
+{
+    fn x(&self) -> T {
+        self.point.x()
+    }
+
+    fn y(&self) -> T {
+        self.point.y()
+    }
+}
+
 /// A rectangle in 2D space constructor
-impl<T> AxisAlignedRectangle<T> {
+impl<T> AxisAlignedRectangle<T>
+where
+    T: Copy,
+{
     pub fn new(point: Point<T>, rectangle: Rectangle<T>) -> Self {
         Self { point, rectangle }
     }
@@ -33,19 +78,20 @@ impl<T: Copy> Rotate for AxisAlignedRectangle<T> {
     }
 }
 
-impl<T: std::ops::Sub<Output = T> + std::ops::Add<Output = T> + Copy> Dividing<T>
-    for AxisAlignedRectangle<T>
+impl<T> Dividing<T> for AxisAlignedRectangle<T>
+where
+    T: Copy + std::ops::Sub<Output = T> + std::ops::Add<Output = T>,
 {
     /// dividing a rectangle into two rectangles (vertical)
     fn divide_vertical(&self, x: T) -> (AxisAlignedRectangle<T>, AxisAlignedRectangle<T>) {
         (
             Self::new(
-                Point::new(self.point.x, self.point.y),
-                Rectangle::new(x, self.rectangle.height),
+                Point::new(self.x(), self.y()),
+                Rectangle::new(x, self.height()),
             ),
             Self::new(
-                Point::new(self.point.x + x, self.point.y),
-                Rectangle::new(self.rectangle.width - x, self.rectangle.height),
+                Point::new(self.x() + x, self.y()),
+                Rectangle::new(self.width() - x, self.height()),
             ),
         )
     }
@@ -54,12 +100,12 @@ impl<T: std::ops::Sub<Output = T> + std::ops::Add<Output = T> + Copy> Dividing<T
     fn divide_horizontal(&self, y: T) -> (AxisAlignedRectangle<T>, AxisAlignedRectangle<T>) {
         (
             Self::new(
-                Point::new(self.point.x, self.point.y),
-                Rectangle::new(self.rectangle.width, y),
+                Point::new(self.x(), self.y()),
+                Rectangle::new(self.width(), y),
             ),
             Self::new(
-                Point::new(self.point.x, self.point.y + y),
-                Rectangle::new(self.rectangle.width, self.rectangle.height - y),
+                Point::new(self.x(), self.y() + y),
+                Rectangle::new(self.width(), self.height() - y),
             ),
         )
     }
@@ -67,6 +113,8 @@ impl<T: std::ops::Sub<Output = T> + std::ops::Add<Output = T> + Copy> Dividing<T
 
 #[cfg(test)]
 mod tests {
+    use crate::dividing::DividingDirection;
+
     use super::*;
 
     #[test]
@@ -74,10 +122,10 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(4, 5);
         let result = AxisAlignedRectangle::new(point, rect);
-        assert_eq!(result.point.x, 2);
-        assert_eq!(result.point.y, 3);
-        assert_eq!(result.rectangle.width, 4);
-        assert_eq!(result.rectangle.height, 5);
+        assert_eq!(result.x(), 2);
+        assert_eq!(result.y(), 3);
+        assert_eq!(result.width(), 4);
+        assert_eq!(result.height(), 5);
     }
 
     #[test]
@@ -85,10 +133,10 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(4, 5);
         let result = AxisAlignedRectangle::new(point, rect).rotate();
-        assert_eq!(result.point.x, 3);
-        assert_eq!(result.point.y, 2);
-        assert_eq!(result.rectangle.width, 5);
-        assert_eq!(result.rectangle.height, 4);
+        assert_eq!(result.x(), 3);
+        assert_eq!(result.y(), 2);
+        assert_eq!(result.width(), 5);
+        assert_eq!(result.height(), 4);
     }
 
     #[test]
@@ -104,14 +152,14 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(4, 5);
         let (rect_a, rect_b) = AxisAlignedRectangle::new(point, rect).divide_vertical(2);
-        assert_eq!(rect_a.point.x, 2);
-        assert_eq!(rect_a.point.y, 3);
-        assert_eq!(rect_a.rectangle.width, 2);
-        assert_eq!(rect_a.rectangle.height, 5);
-        assert_eq!(rect_b.point.x, 4);
-        assert_eq!(rect_b.point.y, 3);
-        assert_eq!(rect_b.rectangle.width, 2);
-        assert_eq!(rect_b.rectangle.height, 5);
+        assert_eq!(rect_a.x(), 2);
+        assert_eq!(rect_a.y(), 3);
+        assert_eq!(rect_a.width(), 2);
+        assert_eq!(rect_a.height(), 5);
+        assert_eq!(rect_b.x(), 4);
+        assert_eq!(rect_b.y(), 3);
+        assert_eq!(rect_b.width(), 2);
+        assert_eq!(rect_b.height(), 5);
     }
 
     #[test]
@@ -119,13 +167,86 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(4, 5);
         let (rect_a, rect_b) = AxisAlignedRectangle::new(point, rect).divide_horizontal(2);
-        assert_eq!(rect_a.point.x, 2);
-        assert_eq!(rect_a.point.y, 3);
-        assert_eq!(rect_a.rectangle.width, 4);
-        assert_eq!(rect_a.rectangle.height, 2);
-        assert_eq!(rect_b.point.x, 2);
-        assert_eq!(rect_b.point.y, 5);
-        assert_eq!(rect_b.rectangle.width, 4);
-        assert_eq!(rect_b.rectangle.height, 3);
+        assert_eq!(rect_a.x(), 2);
+        assert_eq!(rect_a.y(), 3);
+        assert_eq!(rect_a.width(), 4);
+        assert_eq!(rect_a.height(), 2);
+        assert_eq!(rect_b.x(), 2);
+        assert_eq!(rect_b.y(), 5);
+        assert_eq!(rect_b.width(), 4);
+        assert_eq!(rect_b.height(), 3);
+    }
+
+    #[test]
+    fn test_divide_nth() {
+        // test vertical
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(6, 2);
+        let a_rect = AxisAlignedRectangle::new(point, rect);
+        let divided = a_rect.divide_by_values(vec![1, 2], &DividingDirection::Vertical);
+        assert_eq!(divided[0].x(), 2);
+        assert_eq!(divided[0].y(), 3);
+        assert_eq!(divided[0].width(), 1);
+        assert_eq!(divided[0].height(), 2);
+        assert_eq!(divided[1].x(), 3);
+        assert_eq!(divided[1].y(), 3);
+        assert_eq!(divided[1].width(), 2);
+        assert_eq!(divided[1].height(), 2);
+        assert_eq!(divided[2].x(), 5);
+        assert_eq!(divided[2].y(), 3);
+        assert_eq!(divided[2].width(), 3);
+        assert_eq!(divided[2].height(), 2);
+        assert_eq!(divided.len(), 3);
+        // sum of divided rectangles should equal original rectangle
+        assert_eq!(
+            divided[0].width() + divided[1].width() + divided[2].width(),
+            a_rect.width()
+        );
+        // all divided rectangles should have the same height
+        assert_eq!(divided[0].height(), a_rect.height());
+        assert_eq!(divided[1].height(), a_rect.height());
+        assert_eq!(divided[2].height(), a_rect.height());
+        // the sum of the x and width of the  divided rectangle should equal the x of the next divided rectangle
+        assert_eq!(divided[0].x() + divided[0].width(), divided[1].x());
+        assert_eq!(divided[1].x() + divided[1].width(), divided[2].x());
+        assert_eq!(
+            a_rect.x() + a_rect.width(),
+            divided[2].x() + divided[2].width()
+        );
+
+        // test horizontal
+        let point = Point::new(2, 3);
+        let rect = Rectangle::new(2, 6);
+        let a_rect = AxisAlignedRectangle::new(point, rect);
+        let divided = a_rect.divide_by_values(vec![3, 2], &DividingDirection::Horizontal);
+        assert_eq!(divided[0].x(), 2);
+        assert_eq!(divided[0].y(), 3);
+        assert_eq!(divided[0].width(), 2);
+        assert_eq!(divided[0].height(), 3);
+        assert_eq!(divided[1].x(), 2);
+        assert_eq!(divided[1].y(), 6);
+        assert_eq!(divided[1].width(), 2);
+        assert_eq!(divided[1].height(), 2);
+        assert_eq!(divided[2].x(), 2);
+        assert_eq!(divided[2].y(), 8);
+        assert_eq!(divided[2].width(), 2);
+        assert_eq!(divided[2].height(), 1);
+        assert_eq!(divided.len(), 3);
+        // sum of divided rectangles should equal original rectangle
+        assert_eq!(
+            divided[0].height() + divided[1].height() + divided[2].height(),
+            a_rect.height()
+        );
+        // all divided rectangles should have the same width
+        assert_eq!(divided[0].width(), a_rect.width());
+        assert_eq!(divided[1].width(), a_rect.width());
+        assert_eq!(divided[2].width(), a_rect.width());
+        // the sum of the y and height of the  divided rectangle should equal the y of the next divided rectangle
+        assert_eq!(divided[0].y() + divided[0].height(), divided[1].y());
+        assert_eq!(divided[1].y() + divided[1].height(), divided[2].y());
+        assert_eq!(
+            a_rect.y() + a_rect.height(),
+            divided[2].y() + divided[2].height()
+        );
     }
 }

--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -1,10 +1,12 @@
 use crate::component::Component;
+use crate::direction::{Direction, SizeForDirection};
 use crate::dividing::Dividing;
 use crate::point::Point;
 use crate::rectangle::{Area, Rectangle, RectangleSize};
 use crate::rotate::Rotate;
 
 /// axis aligned starting at x, y and ending at x + width, y + height (left to right, top to bottom)
+#[derive(Debug, PartialEq, Clone)]
 pub struct AxisAlignedRectangle<T>
 where
     T: Copy,
@@ -13,15 +15,12 @@ where
     pub rectangle: Rectangle<T>,
 }
 
-impl<T> Clone for AxisAlignedRectangle<T>
+impl<T> SizeForDirection<T> for AxisAlignedRectangle<T>
 where
     T: Copy,
 {
-    fn clone(&self) -> Self {
-        Self {
-            point: self.point.clone(),
-            rectangle: self.rectangle.clone(),
-        }
+    fn size_for_direction(&self, direction: &Direction) -> T {
+        self.rectangle.size_for_direction(direction)
     }
 }
 
@@ -113,7 +112,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::dividing::DividingDirection;
+    use crate::direction::Direction;
 
     use super::*;
 
@@ -183,7 +182,7 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(6, 2);
         let a_rect = AxisAlignedRectangle::new(point, rect);
-        let divided = a_rect.divide_by_values(vec![1, 2], &DividingDirection::Vertical);
+        let divided = a_rect.divide_by_values(vec![1, 2], &Direction::Vertical);
         assert_eq!(divided[0].x(), 2);
         assert_eq!(divided[0].y(), 3);
         assert_eq!(divided[0].width(), 1);
@@ -218,7 +217,7 @@ mod tests {
         let point = Point::new(2, 3);
         let rect = Rectangle::new(2, 6);
         let a_rect = AxisAlignedRectangle::new(point, rect);
-        let divided = a_rect.divide_by_values(vec![3, 2], &DividingDirection::Horizontal);
+        let divided = a_rect.divide_by_values(vec![3, 2], &Direction::Horizontal);
         assert_eq!(divided[0].x(), 2);
         assert_eq!(divided[0].y(), 3);
         assert_eq!(divided[0].width(), 2);

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,0 +1,4 @@
+pub trait Component<T> {
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+}

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -1,0 +1,12 @@
+pub enum Direction {
+    Vertical,
+    Horizontal,
+}
+
+pub trait ValueForDirection<T> {
+    fn value_for_direction(&self, direction: &Direction) -> T;
+}
+
+pub trait SizeForDirection<T> {
+    fn size_for_direction(&self, direction: &Direction) -> T;
+}

--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -1,9 +1,7 @@
-use crate::rectangle::RectangleSize;
-
-pub enum DividingDirection {
-    Vertical,
-    Horizontal,
-}
+use crate::{
+    direction::{Direction, SizeForDirection},
+    rectangle::RectangleSize,
+};
 
 pub trait Dividing<T> {
     /// dividing a rectangle into two rectangles (vertical)
@@ -17,18 +15,18 @@ pub trait Dividing<T> {
         Self: Sized;
 
     /// dividing a rectangle into two rectangles specified by direction
-    fn divide(&self, v: T, direction: &DividingDirection) -> (Self, Self)
+    fn divide(&self, v: T, direction: &Direction) -> (Self, Self)
     where
         Self: Sized,
     {
         match direction {
-            DividingDirection::Vertical => self.divide_vertical(v),
-            DividingDirection::Horizontal => self.divide_horizontal(v),
+            Direction::Vertical => self.divide_vertical(v),
+            Direction::Horizontal => self.divide_horizontal(v),
         }
     }
 
     /// dividing a rectangle into specified number of rectangles specified by direction
-    fn divide_by_values(&self, values: Vec<T>, direction: &DividingDirection) -> Vec<Self>
+    fn divide_by_values(&self, values: Vec<T>, direction: &Direction) -> Vec<Self>
     where
         Self: Sized + RectangleSize<T> + Clone,
         T: Copy,
@@ -42,5 +40,23 @@ pub trait Dividing<T> {
         }
         divided.push(remaining.clone());
         divided
+    }
+
+    /// dividing a rectangle into specified weights of rectangles specified by direction
+    fn divide_by_weights(&self, weights: Vec<T>, direction: &Direction) -> Vec<Self>
+    where
+        Self: Sized + RectangleSize<T> + Clone + SizeForDirection<T>,
+        T: Copy
+            + std::ops::Add<Output = T>
+            + for<'a> std::iter::Sum<&'a T>
+            + std::ops::Div<Output = T>
+            + std::ops::Mul<Output = T>,
+    {
+        let sum_of_weights: T = weights.iter().sum();
+        let size = self.size_for_direction(direction);
+        let values: Vec<T> = weights.iter().map(|w| *w * size / sum_of_weights).collect();
+        // last value is not used
+        let values = values[0..values.len() - 1].to_vec();
+        self.divide_by_values(values, direction)
     }
 }

--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -1,0 +1,8 @@
+pub trait Dividing<T> {
+    fn divide_vertical(&self, x: T) -> (Self, Self)
+    where
+        Self: Sized;
+    fn divide_horizontal(&self, y: T) -> (Self, Self)
+    where
+        Self: Sized;
+}

--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -1,8 +1,46 @@
+use crate::rectangle::RectangleSize;
+
+pub enum DividingDirection {
+    Vertical,
+    Horizontal,
+}
+
 pub trait Dividing<T> {
+    /// dividing a rectangle into two rectangles (vertical)
     fn divide_vertical(&self, x: T) -> (Self, Self)
     where
         Self: Sized;
+
+    /// dividing a rectangle into two rectangles (horizontal)
     fn divide_horizontal(&self, y: T) -> (Self, Self)
     where
         Self: Sized;
+
+    /// dividing a rectangle into two rectangles specified by direction
+    fn divide(&self, v: T, direction: &DividingDirection) -> (Self, Self)
+    where
+        Self: Sized,
+    {
+        match direction {
+            DividingDirection::Vertical => self.divide_vertical(v),
+            DividingDirection::Horizontal => self.divide_horizontal(v),
+        }
+    }
+
+    /// dividing a rectangle into specified number of rectangles specified by direction
+    fn divide_by_values(&self, values: Vec<T>, direction: &DividingDirection) -> Vec<Self>
+    where
+        Self: Sized + RectangleSize<T> + Clone,
+        T: Copy,
+    {
+        let mut remaining = self.clone();
+        let mut divided: Vec<Self> = Vec::new();
+        for v in values {
+            let (divided1, divided2) = remaining.divide(v, direction);
+            divided.push(divided1);
+            remaining = divided2;
+        }
+        divided.push(remaining.clone());
+        divided
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,2 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod point;
+pub mod vector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod axis_aligned_rectangle;
+pub mod dividing;
 pub mod point;
 pub mod rectangle;
 pub mod rotate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod axis_aligned_rectangle;
+pub mod component;
 pub mod dividing;
 pub mod point;
 pub mod rectangle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod axis_aligned_rectangle;
 pub mod point;
+pub mod rectangle;
+pub mod rotate;
 pub mod vector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod axis_aligned_rectangle;
 pub mod component;
+pub mod direction;
 pub mod dividing;
 pub mod point;
 pub mod rectangle;

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,7 +1,9 @@
 use crate::component::Component;
+use crate::direction::{Direction, ValueForDirection};
 use crate::rotate::Rotate;
 use crate::vector::Vector;
 /// A point in 2D space
+#[derive(Debug, PartialEq, Clone)]
 pub struct Point<T>
 where
     T: Copy,
@@ -10,14 +12,14 @@ where
     y: T,
 }
 
-impl<T> Clone for Point<T>
+impl<T> ValueForDirection<T> for Point<T>
 where
     T: Copy,
 {
-    fn clone(&self) -> Self {
-        Self {
-            x: self.x,
-            y: self.y,
+    fn value_for_direction(&self, direction: &Direction) -> T {
+        match direction {
+            Direction::Vertical => self.x,
+            Direction::Horizontal => self.y,
         }
     }
 }
@@ -46,11 +48,11 @@ where
 }
 
 /// A point in 2D space with default values. in many cases, this is (0, 0)
-impl<T> Point<T>
+impl<T> std::default::Default for Point<T>
 where
     T: Default + Copy,
 {
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self::new(T::default(), T::default())
     }
 }
@@ -96,6 +98,13 @@ mod tests {
         let result = Point::<i32>::default();
         assert_eq!(result.x, 0);
         assert_eq!(result.y, 0);
+    }
+
+    #[test]
+    fn test_value_for_direction() {
+        let result = Point::new(2, 3);
+        assert_eq!(result.value_for_direction(&Direction::Vertical), 2);
+        assert_eq!(result.value_for_direction(&Direction::Horizontal), 3);
     }
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,0 +1,58 @@
+use crate::vector::Vector;
+
+/// A point in 2D space
+pub struct Point<T> {
+    pub x: T,
+    pub y: T,
+}
+
+/// A point in 2D space constructor
+impl<T> Point<T> {
+    pub fn new(x: T, y: T) -> Self {
+        Point { x, y }
+    }
+}
+
+/// A point in 2D space with default values. in many cases, this is (0, 0)
+impl<T: Default> Point<T> {
+    pub fn default() -> Self {
+        Self::new(T::default(), T::default())
+    }
+}
+
+/// Vector from point A to point B
+impl<T: std::ops::Sub<Output = T>> std::ops::Sub<Point<T>> for Point<T> {
+    type Output = Vector<T>;
+
+    fn sub(self, rhs: Point<T>) -> Self::Output {
+        Vector::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let result = Point::new(2, 2);
+        assert_eq!(result.x, 2);
+        assert_eq!(result.y, 2);
+    }
+
+    #[test]
+    fn test_default() {
+        let result = Point::<i32>::default();
+        assert_eq!(result.x, 0);
+        assert_eq!(result.y, 0);
+    }
+
+    #[test]
+    fn test_sub() {
+        let a = Point::new(2, 2);
+        let b = Point::new(1, 1);
+        let result = a - b;
+        assert_eq!(result.x, 1);
+        assert_eq!(result.y, 1);
+    }
+}

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,28 +1,65 @@
+use crate::component::Component;
 use crate::rotate::Rotate;
 use crate::vector::Vector;
-
 /// A point in 2D space
-pub struct Point<T> {
-    pub x: T,
-    pub y: T,
+pub struct Point<T>
+where
+    T: Copy,
+{
+    x: T,
+    y: T,
+}
+
+impl<T> Clone for Point<T>
+where
+    T: Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            x: self.x,
+            y: self.y,
+        }
+    }
+}
+
+impl<T> Component<T> for Point<T>
+where
+    T: Copy,
+{
+    fn x(&self) -> T {
+        self.x
+    }
+
+    fn y(&self) -> T {
+        self.y
+    }
 }
 
 /// A point in 2D space constructor
-impl<T> Point<T> {
+impl<T> Point<T>
+where
+    T: Copy,
+{
     pub fn new(x: T, y: T) -> Self {
         Point { x, y }
     }
 }
 
 /// A point in 2D space with default values. in many cases, this is (0, 0)
-impl<T: Default> Point<T> {
+impl<T> Point<T>
+where
+    T: Default + Copy,
+{
     pub fn default() -> Self {
         Self::new(T::default(), T::default())
     }
 }
 
 /// Vector from point A to point B
-impl<T: std::ops::Sub<Output = T>> std::ops::Sub<Point<T>> for Point<T> {
+impl<T> std::ops::Sub<Point<T>> for Point<T>
+where
+    T: Copy + std::ops::Sub<Output = T>,
+{
     type Output = Vector<T>;
 
     fn sub(self, rhs: Point<T>) -> Self::Output {
@@ -31,7 +68,10 @@ impl<T: std::ops::Sub<Output = T>> std::ops::Sub<Point<T>> for Point<T> {
 }
 
 /// Rotate a point by 90 degrees
-impl<T: Copy> Rotate for Point<T> {
+impl<T> Rotate for Point<T>
+where
+    T: Copy,
+{
     fn rotate(&self) -> Self {
         Point {
             x: self.y,
@@ -63,8 +103,8 @@ mod tests {
         let a = Point::new(2, 2);
         let b = Point::new(1, 1);
         let result = a - b;
-        assert_eq!(result.x, 1);
-        assert_eq!(result.y, 1);
+        assert_eq!(result.x(), 1);
+        assert_eq!(result.y(), 1);
     }
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,3 +1,4 @@
+use crate::rotate::Rotate;
 use crate::vector::Vector;
 
 /// A point in 2D space
@@ -29,6 +30,16 @@ impl<T: std::ops::Sub<Output = T>> std::ops::Sub<Point<T>> for Point<T> {
     }
 }
 
+/// Rotate a point by 90 degrees
+impl<T: Copy> Rotate for Point<T> {
+    fn rotate(&self) -> Self {
+        Point {
+            x: self.y,
+            y: self.x,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,5 +65,12 @@ mod tests {
         let result = a - b;
         assert_eq!(result.x, 1);
         assert_eq!(result.y, 1);
+    }
+
+    #[test]
+    fn test_rotate() {
+        let result = Point::new(2, 3).rotate();
+        assert_eq!(result.x, 3);
+        assert_eq!(result.y, 2);
     }
 }

--- a/src/point/lib.rs
+++ b/src/point/lib.rs
@@ -1,0 +1,4 @@
+pub struct Point<T> {
+    x: T,
+    y: T,
+}

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,9 +1,46 @@
 use crate::dividing::Dividing;
 use crate::rotate::Rotate;
 /// rectangle in 2D space with a width and height
-pub struct Rectangle<T> {
-    pub width: T,
-    pub height: T,
+pub struct Rectangle<T>
+where
+    T: Copy,
+{
+    width: T,
+    height: T,
+}
+
+impl<T> Clone for Rectangle<T>
+where
+    T: Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
+pub trait RectangleSize<T>
+where
+    T: Copy,
+{
+    fn width(&self) -> T;
+    fn height(&self) -> T;
+}
+
+/// A rectangle in 2D space with a width and height
+impl<T> RectangleSize<T> for Rectangle<T>
+where
+    T: Copy,
+{
+    fn width(&self) -> T {
+        self.width
+    }
+
+    fn height(&self) -> T {
+        self.height
+    }
 }
 
 /// Area of an axis aligned rectangle
@@ -12,14 +49,20 @@ pub trait Area<T> {
 }
 
 /// A rectangle in 2D space constructor
-impl<T> Rectangle<T> {
+impl<T> Rectangle<T>
+where
+    T: Copy,
+{
     pub fn new(width: T, height: T) -> Self {
         Self { width, height }
     }
 }
 
 /// Rotate a rectangle by 90 degrees
-impl<T: Copy> Rotate for Rectangle<T> {
+impl<T> Rotate for Rectangle<T>
+where
+    T: Copy,
+{
     fn rotate(&self) -> Self {
         Self {
             width: self.height,
@@ -29,13 +72,19 @@ impl<T: Copy> Rotate for Rectangle<T> {
 }
 
 /// Area of a rectangle
-impl<T: std::ops::Mul<Output = T> + Copy> Rectangle<T> {
+impl<T> Rectangle<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
     pub fn area(&self) -> T {
         self.width * self.height
     }
 }
 
-impl<T: std::ops::Sub<Output = T> + Copy> Dividing<T> for Rectangle<T> {
+impl<T> Dividing<T> for Rectangle<T>
+where
+    T: Copy + std::ops::Sub<Output = T>,
+{
     /// dividing a rectangle into two rectangles (vertical)
     fn divide_vertical(&self, x: T) -> (Rectangle<T>, Rectangle<T>) {
         (
@@ -55,6 +104,8 @@ impl<T: std::ops::Sub<Output = T> + Copy> Dividing<T> for Rectangle<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::dividing::DividingDirection;
+
     use super::*;
 
     #[test]
@@ -93,5 +144,41 @@ mod tests {
         assert_eq!(rect_a.height, 1);
         assert_eq!(rect_b.width, 2);
         assert_eq!(rect_b.height, 3);
+    }
+
+    #[test]
+    fn test_divide() {
+        let (rect_a, rect_b) = Rectangle::new(4, 2).divide(1, &DividingDirection::Vertical);
+        assert_eq!(rect_a.width, 1);
+        assert_eq!(rect_a.height, 2);
+        assert_eq!(rect_b.width, 3);
+        assert_eq!(rect_b.height, 2);
+
+        let (rect_a, rect_b) = Rectangle::new(2, 4).divide(1, &DividingDirection::Horizontal);
+        assert_eq!(rect_a.width, 2);
+        assert_eq!(rect_a.height, 1);
+        assert_eq!(rect_b.width, 2);
+        assert_eq!(rect_b.height, 3);
+    }
+
+    #[test]
+    fn test_divide_nth() {
+        let rect = Rectangle::new(6, 2);
+        let divided = rect.divide_by_values(vec![1, 2], &DividingDirection::Vertical);
+        assert_eq!(divided[0].width, 1);
+        assert_eq!(divided[0].height, 2);
+        assert_eq!(divided[1].width, 2);
+        assert_eq!(divided[1].height, 2);
+        assert_eq!(divided[2].width, 3);
+        assert_eq!(divided[2].height, 2);
+
+        let rect = Rectangle::new(2, 6);
+        let divided = rect.divide_by_values(vec![3, 2], &DividingDirection::Horizontal);
+        assert_eq!(divided[0].width, 2);
+        assert_eq!(divided[0].height, 3);
+        assert_eq!(divided[1].width, 2);
+        assert_eq!(divided[1].height, 2);
+        assert_eq!(divided[2].width, 2);
+        assert_eq!(divided[2].height, 1);
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,0 +1,60 @@
+use crate::rotate::Rotate;
+/// rectangle in 2D space with a width and height
+pub struct Rectangle<T> {
+    pub width: T,
+    pub height: T,
+}
+
+/// Area of an axis aligned rectangle
+pub trait Area<T> {
+    fn area(&self) -> T;
+}
+
+/// A rectangle in 2D space constructor
+impl<T> Rectangle<T> {
+    pub fn new(width: T, height: T) -> Self {
+        Rectangle { width, height }
+    }
+}
+
+/// Rotate a rectangle by 90 degrees
+impl<T: Copy> Rotate for Rectangle<T> {
+    fn rotate(&self) -> Self {
+        Rectangle {
+            width: self.height,
+            height: self.width,
+        }
+    }
+}
+
+/// Area of a rectangle
+impl<T: std::ops::Mul<Output = T> + Copy> Rectangle<T> {
+    pub fn area(&self) -> T {
+        self.width * self.height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let result = Rectangle::new(2, 2);
+        assert_eq!(result.width, 2);
+        assert_eq!(result.height, 2);
+    }
+
+    #[test]
+    fn test_rotate() {
+        let result = Rectangle::new(2, 3).rotate();
+        assert_eq!(result.width, 3);
+        assert_eq!(result.height, 2);
+    }
+
+    #[test]
+    fn test_area() {
+        let result = Rectangle::new(2, 3).area();
+        assert_eq!(result, 6);
+    }
+}

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,6 +1,9 @@
+use crate::direction::{Direction, SizeForDirection};
 use crate::dividing::Dividing;
 use crate::rotate::Rotate;
 /// rectangle in 2D space with a width and height
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct Rectangle<T>
 where
     T: Copy,
@@ -9,14 +12,14 @@ where
     height: T,
 }
 
-impl<T> Clone for Rectangle<T>
+impl<T> SizeForDirection<T> for Rectangle<T>
 where
     T: Copy,
 {
-    fn clone(&self) -> Self {
-        Self {
-            width: self.width,
-            height: self.height,
+    fn size_for_direction(&self, direction: &Direction) -> T {
+        match direction {
+            Direction::Vertical => self.width,
+            Direction::Horizontal => self.height,
         }
     }
 }
@@ -48,6 +51,15 @@ pub trait Area<T> {
     fn area(&self) -> T;
 }
 
+impl<T> Area<T> for Rectangle<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
+    fn area(&self) -> T {
+        self.width * self.height
+    }
+}
+
 /// A rectangle in 2D space constructor
 impl<T> Rectangle<T>
 where
@@ -68,16 +80,6 @@ where
             width: self.height,
             height: self.width,
         }
-    }
-}
-
-/// Area of a rectangle
-impl<T> Rectangle<T>
-where
-    T: std::ops::Mul<Output = T> + Copy,
-{
-    pub fn area(&self) -> T {
-        self.width * self.height
     }
 }
 
@@ -104,7 +106,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::dividing::DividingDirection;
+    use crate::direction::Direction;
 
     use super::*;
 
@@ -148,13 +150,13 @@ mod tests {
 
     #[test]
     fn test_divide() {
-        let (rect_a, rect_b) = Rectangle::new(4, 2).divide(1, &DividingDirection::Vertical);
+        let (rect_a, rect_b) = Rectangle::new(4, 2).divide(1, &Direction::Vertical);
         assert_eq!(rect_a.width, 1);
         assert_eq!(rect_a.height, 2);
         assert_eq!(rect_b.width, 3);
         assert_eq!(rect_b.height, 2);
 
-        let (rect_a, rect_b) = Rectangle::new(2, 4).divide(1, &DividingDirection::Horizontal);
+        let (rect_a, rect_b) = Rectangle::new(2, 4).divide(1, &Direction::Horizontal);
         assert_eq!(rect_a.width, 2);
         assert_eq!(rect_a.height, 1);
         assert_eq!(rect_b.width, 2);
@@ -164,7 +166,7 @@ mod tests {
     #[test]
     fn test_divide_nth() {
         let rect = Rectangle::new(6, 2);
-        let divided = rect.divide_by_values(vec![1, 2], &DividingDirection::Vertical);
+        let divided = rect.divide_by_values(vec![1, 2], &Direction::Vertical);
         assert_eq!(divided[0].width, 1);
         assert_eq!(divided[0].height, 2);
         assert_eq!(divided[1].width, 2);
@@ -173,12 +175,23 @@ mod tests {
         assert_eq!(divided[2].height, 2);
 
         let rect = Rectangle::new(2, 6);
-        let divided = rect.divide_by_values(vec![3, 2], &DividingDirection::Horizontal);
+        let divided = rect.divide_by_values(vec![3, 2], &Direction::Horizontal);
         assert_eq!(divided[0].width, 2);
         assert_eq!(divided[0].height, 3);
         assert_eq!(divided[1].width, 2);
         assert_eq!(divided[1].height, 2);
         assert_eq!(divided[2].width, 2);
         assert_eq!(divided[2].height, 1);
+    }
+
+    #[test]
+    fn test_divide_by_weights() {
+        let rect = Rectangle::new(6, 2);
+        // values
+        let divided1 = rect.divide_by_values(vec![1, 2], &Direction::Vertical);
+
+        let rect = Rectangle::new(6, 2);
+        let divided2 = rect.divide_by_weights(vec![2, 4, 6], &Direction::Vertical);
+        assert_eq!(divided1, divided2);
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,3 +1,4 @@
+use crate::dividing::Dividing;
 use crate::rotate::Rotate;
 /// rectangle in 2D space with a width and height
 pub struct Rectangle<T> {
@@ -13,14 +14,14 @@ pub trait Area<T> {
 /// A rectangle in 2D space constructor
 impl<T> Rectangle<T> {
     pub fn new(width: T, height: T) -> Self {
-        Rectangle { width, height }
+        Self { width, height }
     }
 }
 
 /// Rotate a rectangle by 90 degrees
 impl<T: Copy> Rotate for Rectangle<T> {
     fn rotate(&self) -> Self {
-        Rectangle {
+        Self {
             width: self.height,
             height: self.width,
         }
@@ -31,6 +32,24 @@ impl<T: Copy> Rotate for Rectangle<T> {
 impl<T: std::ops::Mul<Output = T> + Copy> Rectangle<T> {
     pub fn area(&self) -> T {
         self.width * self.height
+    }
+}
+
+impl<T: std::ops::Sub<Output = T> + Copy> Dividing<T> for Rectangle<T> {
+    /// dividing a rectangle into two rectangles (vertical)
+    fn divide_vertical(&self, x: T) -> (Rectangle<T>, Rectangle<T>) {
+        (
+            Self::new(x, self.height),
+            Self::new(self.width - x, self.height),
+        )
+    }
+
+    /// dividing a rectangle into two rectangles (horizontal)
+    fn divide_horizontal(&self, y: T) -> (Rectangle<T>, Rectangle<T>) {
+        (
+            Self::new(self.width, y),
+            Self::new(self.width, self.height - y),
+        )
     }
 }
 
@@ -56,5 +75,23 @@ mod tests {
     fn test_area() {
         let result = Rectangle::new(2, 3).area();
         assert_eq!(result, 6);
+    }
+
+    #[test]
+    fn test_divide_vertical() {
+        let (rect_a, rect_b) = Rectangle::new(4, 2).divide_vertical(1);
+        assert_eq!(rect_a.width, 1);
+        assert_eq!(rect_a.height, 2);
+        assert_eq!(rect_b.width, 3);
+        assert_eq!(rect_b.height, 2);
+    }
+
+    #[test]
+    fn test_divide_horizontal() {
+        let (rect_a, rect_b) = Rectangle::new(2, 4).divide_horizontal(1);
+        assert_eq!(rect_a.width, 2);
+        assert_eq!(rect_a.height, 1);
+        assert_eq!(rect_b.width, 2);
+        assert_eq!(rect_b.height, 3);
     }
 }

--- a/src/rotate.rs
+++ b/src/rotate.rs
@@ -1,0 +1,5 @@
+/// Rotate a points, shapes, vectors, etc.
+
+pub trait Rotate {
+    fn rotate(&self) -> Self;
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,56 @@
+/// A simple 2D vector
+pub struct Vector<T> {
+    pub x: T,
+    pub y: T,
+}
+
+/// A simple 2D vector constructor
+impl<T> Vector<T> {
+    pub fn new(x: T, y: T) -> Self {
+        Vector { x, y }
+    }
+}
+
+/// A simple 2D vector with default values. in many cases, this is (0, 0)
+impl<T: Default> Vector<T> {
+    pub fn default() -> Self {
+        Self::new(T::default(), T::default())
+    }
+}
+
+/// Add vector A to vector B
+impl<T: std::ops::Add<Output = T>> std::ops::Add<Vector<T>> for Vector<T> {
+    type Output = Vector<T>;
+
+    fn add(self, rhs: Vector<T>) -> Self::Output {
+        Vector::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let result = Vector::new(2, 2);
+        assert_eq!(result.x, 2);
+        assert_eq!(result.y, 2);
+    }
+
+    #[test]
+    fn test_default() {
+        let result = Vector::<i32>::default();
+        assert_eq!(result.x, 0);
+        assert_eq!(result.y, 0);
+    }
+
+    #[test]
+    fn test_add() {
+        let a = Vector::new(2, 2);
+        let b = Vector::new(1, 1);
+        let result = a + b;
+        assert_eq!(result.x, 3);
+        assert_eq!(result.y, 3);
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,29 +1,67 @@
+use crate::component::Component;
+
 /// A simple 2D vector
-pub struct Vector<T> {
-    pub x: T,
-    pub y: T,
+pub struct Vector<T>
+where
+    T: Copy,
+{
+    x: T,
+    y: T,
 }
 
 /// A simple 2D vector constructor
-impl<T> Vector<T> {
+impl<T> Vector<T>
+where
+    T: Copy,
+{
     pub fn new(x: T, y: T) -> Self {
-        Vector { x, y }
+        Self { x, y }
+    }
+}
+
+impl<T> Component<T> for Vector<T>
+where
+    T: Copy,
+{
+    fn x(&self) -> T {
+        self.x
+    }
+    fn y(&self) -> T {
+        self.y
     }
 }
 
 /// A simple 2D vector with default values. in many cases, this is (0, 0)
-impl<T: Default> Vector<T> {
+impl<T> Vector<T>
+where
+    T: Copy + Default,
+{
     pub fn default() -> Self {
         Self::new(T::default(), T::default())
     }
 }
 
 /// Add vector A to vector B
-impl<T: std::ops::Add<Output = T>> std::ops::Add<Vector<T>> for Vector<T> {
+impl<T> std::ops::Add<Vector<T>> for Vector<T>
+where
+    T: Copy + std::ops::Add<Output = T>,
+{
     type Output = Vector<T>;
 
     fn add(self, rhs: Vector<T>) -> Self::Output {
         Vector::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+/// Subtract vector B from vector A
+impl<T> std::ops::Sub<Vector<T>> for Vector<T>
+where
+    T: Copy + std::ops::Sub<Output = T>,
+{
+    type Output = Vector<T>;
+
+    fn sub(self, rhs: Vector<T>) -> Self::Output {
+        Vector::new(self.x - rhs.x, self.y - rhs.y)
     }
 }
 
@@ -34,15 +72,15 @@ mod tests {
     #[test]
     fn test_new() {
         let result = Vector::new(2, 2);
-        assert_eq!(result.x, 2);
-        assert_eq!(result.y, 2);
+        assert_eq!(result.x(), 2);
+        assert_eq!(result.y(), 2);
     }
 
     #[test]
     fn test_default() {
         let result = Vector::<i32>::default();
-        assert_eq!(result.x, 0);
-        assert_eq!(result.y, 0);
+        assert_eq!(result.x(), 0);
+        assert_eq!(result.y(), 0);
     }
 
     #[test]
@@ -50,7 +88,7 @@ mod tests {
         let a = Vector::new(2, 2);
         let b = Vector::new(1, 1);
         let result = a + b;
-        assert_eq!(result.x, 3);
-        assert_eq!(result.y, 3);
+        assert_eq!(result.x(), 3);
+        assert_eq!(result.y(), 3);
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,8 @@
 use crate::component::Component;
+use crate::direction::{Direction, ValueForDirection};
 
 /// A simple 2D vector
+#[derive(Debug, PartialEq, Clone)]
 pub struct Vector<T>
 where
     T: Copy,
@@ -31,12 +33,24 @@ where
     }
 }
 
+impl<T> ValueForDirection<T> for Vector<T>
+where
+    T: Copy,
+{
+    fn value_for_direction(&self, direction: &Direction) -> T {
+        match direction {
+            Direction::Vertical => self.x,
+            Direction::Horizontal => self.y,
+        }
+    }
+}
+
 /// A simple 2D vector with default values. in many cases, this is (0, 0)
-impl<T> Vector<T>
+impl<T> std::default::Default for Vector<T>
 where
     T: Copy + Default,
 {
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self::new(T::default(), T::default())
     }
 }


### PR DESCRIPTION
## What this project aims

This project aims to make a Rust version of https://github.com/kitsuyui/js-rectangle-dividing

Rust can output wasm, so if this project goes well, we can provide wasm version of js-rectangle-dividing.
js-rectangle-dividing has a feature to divide rectangles with some conditions.
The division requires geometric calculation, and JS object and Rust struct have totally different calculation efficiency.
