### PR TITLE
Update wasm target to bundler

### DIFF
--- a/.github/workflows/wasm-npm-publish.yml
+++ b/.github/workflows/wasm-npm-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: |
           # wasm-pack test --node --firefox --chrome --safari --headless
-          wasm-pack build --release --target web --scope kitsuyui
+          wasm-pack build --release --target bundler --scope kitsuyui
           jq '.name|="@kitsuyui/rectangle-dividing"' pkg/package.json > pkg/package.json.bak
           mv pkg/package.json.bak pkg/package.json
           wasm-pack pack


### PR DESCRIPTION
- This module will be used in both node and browser environments.
- So the target should be bundler.
