### PR TITLE
Update rust edition 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rectangle-dividing"
 version = "0.1.4"
-edition = "2021"
+edition = "2024"
 description = "A rectangle dividing algorithm written in Rust"
 repository = "https://github.com/kitsuyui/rust-rectangle-dividing/"
 license = "MIT"

--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -88,7 +88,7 @@ pub trait Dividing<T> {
         let mut divided: Vec<Self> = Vec::new();
 
         remaining_weights.reverse(); // pop() removes item from the end of the vector, so reverse it
-                                     // pick weights until the aspect ratio is satisfied
+        // pick weights until the aspect ratio is satisfied
         while let Some(picked_weight) = remaining_weights.pop() {
             picked_weights.push(picked_weight);
             let weights_in_group = picked_weights.iter().sum::<T>();

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -202,7 +202,7 @@ mod tests {
         let divided1 = rect.divide_by_values_and_axis(&vec![1.0, 2.0], Axis::Vertical);
 
         let rect = Rectangle::new(6.0, 2.0);
-        let divided2 = rect.divide_by_weights_and_axis(&vec![2.0, 4.0, 6.0], Axis::Vertical);
+        let divided2 = rect.divide_by_weights_and_axis(&[2.0, 4.0, 6.0], Axis::Vertical);
         assert_eq!(divided1, divided2);
     }
 


### PR DESCRIPTION
- Updated Cargo.toml to set Rust edition to 2024
