### PR TITLE
Fix JavaScript argument order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ dividing's arguments are
 
 - `rect`: The rectangle to be divided
 - `weights`: The weights of each rectangle
-- `isVertical`: The direction of the first division
 - `aspectRatio`: The aspect ratio of each rectangle
+- `verticalFirst`: The direction of the first division
 - `boustrophedon`: The direction of the next division in the same level
 
 # License


### PR DESCRIPTION
## Summary
- Align the README argument list with the JavaScript example and wasm binding signature.
- Rename the documented first-division flag from `isVertical` to `verticalFirst` and list it after `aspectRatio`.

## Verification
- cargo test
- git diff --check
