### PR TITLE
Add shellcheck guard for wasm packaging

### DIFF
--- a/.github/workflows/wasm-npm-publish.yml
+++ b/.github/workflows/wasm-npm-publish.yml
@@ -12,6 +12,16 @@ env:
   VERSION: ${{ (github.event_name == 'release' && !github.event.release.prerelease) && github.ref_name || github.sha }}
 
 jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Check package metadata helper
+        run: shellcheck update-package-json.sh
+
   build:
     name: build
     runs-on: ubuntu-latest

--- a/update-package-json.sh
+++ b/update-package-json.sh
@@ -6,7 +6,7 @@ inplace() {
   shift
   local tmp
   tmp=$(mktemp)
-  echo "Running: $@"
+  echo "Running: $*"
   "$@" < "$file" > "$tmp"
   mv "$tmp" "$file"
   rm -f "$tmp"


### PR DESCRIPTION
## Summary
- fix the package metadata helper so ShellCheck accepts its command logging
- add a ShellCheck job to the wasm package workflow

## Verification
- shellcheck update-package-json.sh
- bash -n update-package-json.sh
- actionlint .github/workflows/wasm-npm-publish.yml
- cargo test
- git diff --check