### PR TITLE
Pin coverage workflow action refs

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -14,18 +14,18 @@ jobs:
   octocov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: |
-          cargo install cargo-llvm-cov || true
+          cargo install cargo-llvm-cov --version 0.8.5 --locked || true
           cargo llvm-cov --lcov --output-path coverage.lcov
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary

- Pin the coverage workflow action references to their currently resolved commit SHAs.
- Pin `cargo-llvm-cov` installation to version 0.8.5 with `--locked`.
- Keep the existing coverage triggers, permissions, and Octocov configuration unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/octocov.yml"); puts "yaml ok"'\n- actionlint .github/workflows/octocov.yml\n- cargo fmt --all -- --check\n- cargo check\n- cargo clippy -- -D warnings\n- cargo build\n- cargo test\n- cargo install cargo-llvm-cov --version 0.8.5 --locked\n- cargo llvm-cov --lcov --output-path coverage.lcov\n