### PR TITLE
Set test workflow token permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
## Summary
- set the test workflow GITHUB_TOKEN permissions to read-only contents access
- avoid relying on repository default workflow token permissions for test jobs

## Verification
- actionlint .github/workflows/test.yml
- git diff --check
- cargo fmt --all -- --check
- cargo check
- cargo test
- cargo clippy -- -D warnings