### PR TITLE
Pin write-capable reusable workflow refs to commit SHA

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@0b691527a4dde052c79eae22706131a7726a2bba # main

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@0b691527a4dde052c79eae22706131a7726a2bba # main


### PR DESCRIPTION
## Summary

- Pin `kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml` and `kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml` from `@main` to a full commit SHA in `.github/workflows/happy.yml` and `.github/workflows/gitignore-in.yml`.
- Keep `# main` as a tracking comment so Renovate's `github-actions` manager can still update the pin via PR.

## Why

Both workflows call reusable workflows that run with write-capable permissions (`contents: write`, `pull-requests: write`, `issues: write`). With a mutable `@main` ref, the body that uses those tokens can change without review in this repository.

Pinning to a full commit SHA closes that drift while keeping the comment so updates remain visible and reviewable.

## Validation

- `ruby -ryaml -e "YAML.load_file('.github/workflows/happy.yml'); YAML.load_file('.github/workflows/gitignore-in.yml')"`
- `git diff --check`