### PR TITLE
Pin Spellcheck reusable workflow ref to a 40-character commit SHA

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

Pin the one external `uses:` reference in `.github/workflows/spellcheck.yml`
to a 40-character commit SHA so that upstream `main` movement cannot
silently change Spellcheck behavior in CI:

| File | Before | After |
| --- | --- | --- |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

The pinned SHA matches the current tip of `kitsuyui/gh-actions-workflows`
default branch and is identical to the value already adopted by other
kitsuyui org repos (e.g. `mure`, `myip`, `just-submodules-hub`).

Renovate already extends `helpers:pinGitHubActionDigests` via
`local>kitsuyui/renovate-config`, so future digest updates continue
through automated PRs.

## Test plan

- [x] `git diff` confirms only the one `uses:` line changes
- [x] SHA matches `kitsuyui/gh-actions-workflows` `main` tip via `gh api repos/kitsuyui/gh-actions-workflows/git/refs/heads/main`