### PR TITLE
Fix aspect_ratio panicking or returning NaN when height is zero

### DIFF
--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -86,6 +86,12 @@ pub trait Dividing<T> {
         let total_area = self.area();
         let height = self.height();
 
+        // A zero-height rectangle cannot produce a meaningful aspect ratio; skip the
+        // grouping algorithm and distribute weights along the vertical axis directly.
+        if height == T::zero() {
+            return self.divide_by_weights_and_axis(&norm_weights, Axis::Vertical);
+        }
+
         let mut dividing_weights: Vec<Vec<T>> = Vec::new();
 
         let mut remaining_weights = norm_weights;
@@ -431,6 +437,22 @@ mod tests {
         assert_rects_are_finite(&divided);
         assert_weights_dividing(&rect, &divided, &[-1.0, 1.0]);
         assert_no_overlaps(&rect, &divided);
+    }
+
+    #[test]
+    fn test_divide_zero_height_rect() {
+        let rect = AxisAlignedRectangle::from4values(0.0, 0.0, 90.0, 0.0);
+        let weights = [1.0_f64, 1.0, 1.0];
+
+        let vertical_first =
+            rect.divide_vertical_then_horizontal_with_weights(&weights, 1.0, false);
+        assert_eq!(vertical_first.len(), weights.len());
+        assert_rects_are_finite(&vertical_first);
+
+        let horizontal_first =
+            rect.divide_horizontal_then_vertical_with_weights(&weights, 1.0, false);
+        assert_eq!(horizontal_first.len(), weights.len());
+        assert_rects_are_finite(&horizontal_first);
     }
 
     #[test]

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -111,6 +111,9 @@ where
     T: Copy + Num + NumAssignOps + NumOps,
 {
     fn aspect_ratio(&self) -> T {
+        if self.height == T::zero() {
+            return T::zero();
+        }
         self.width / self.height
     }
 }
@@ -153,6 +156,20 @@ mod tests {
         assert_eq!(result, 1.7777777777777777);
         let result = Rectangle::new(1920.0, 1080.0).aspect_ratio();
         assert_eq!(result, 1.7777777777777777);
+    }
+
+    #[test]
+    fn test_aspect_ratio_zero_height() {
+        // Zero height must not panic (integer) or return NaN/Inf (float).
+        let result = Rectangle::new(16.0_f64, 0.0).aspect_ratio();
+        assert_eq!(result, 0.0);
+        assert!(result.is_finite());
+
+        let result = Rectangle::new(0.0_f64, 0.0).aspect_ratio();
+        assert_eq!(result, 0.0);
+
+        let result = Rectangle::new(5_i32, 0_i32).aspect_ratio();
+        assert_eq!(result, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`aspect_ratio()` computed `self.width / self.height` without checking for `height == 0`. For integer types (`i32`, `i64`) this caused a panic on division by zero; for float types (`f32`, `f64`) it produced `NaN` or `Inf`, which then silently corrupted downstream layout calculations including the WASM API output.

**Changes**

- `src/rectangle.rs`: Return `T::zero()` from `aspect_ratio()` when `height == 0`, preventing both the panic and NaN paths. (The `AxisAlignedRectangle` implementation delegates to this, so it is also fixed.)
- `src/dividing.rs`: Add an early return at the start of `divide_vertical_then_horizontal_with_weights` when `height == 0`. The algorithm performs two divisions by height (`picked_area / height` and `first_item_height = ... * height`); when `height == 0` and `area == 0`, the first becomes `0/0 = NaN` for floats or panics for integers. The early return delegates to `divide_by_weights_and_axis` which distributes the zero-height rectangle along the vertical axis without any division by height.
- New tests: `test_aspect_ratio_zero_height` (covers `f64` non-zero width, `f64` zero×zero, `i32` zero height) and `test_divide_zero_height_rect` (both layout methods).

## Test plan

- `cargo test` — all 42 tests pass
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --check` — no formatting differences