### PR TITLE
Add geometric input validation to WASM dividing() API

### DIFF
--- a/src/wasm_binding.rs
+++ b/src/wasm_binding.rs
@@ -32,6 +32,9 @@ pub fn dividing(
     let Ok(rect) = serde_wasm_bindgen::from_value::<JSRect>(rect) else {
         return Err(JsValue::from_str("failed to parse rect"));
     };
+    if rect.w <= 0.0 || rect.h <= 0.0 {
+        return Err(JsValue::from_str("rect.w and rect.h must be positive"));
+    }
     let rect =
         AxisAlignedRectangle::new(&Point::new(rect.x, rect.y), &Rectangle::new(rect.w, rect.h));
     let rects = match vertical_first {
@@ -61,6 +64,54 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;
+
+    #[wasm_bindgen_test]
+    fn test_negative_dimensions_rejected() {
+        let result = dividing(
+            serde_wasm_bindgen::to_value(&JSRect {
+                x: 0.0,
+                y: 0.0,
+                w: -10.0,
+                h: 100.0,
+            })
+            .unwrap(),
+            &[1.0, 1.0],
+            1.0,
+            true,
+            false,
+        );
+        assert!(result.is_err());
+
+        let result = dividing(
+            serde_wasm_bindgen::to_value(&JSRect {
+                x: 0.0,
+                y: 0.0,
+                w: 100.0,
+                h: -5.0,
+            })
+            .unwrap(),
+            &[1.0, 1.0],
+            1.0,
+            true,
+            false,
+        );
+        assert!(result.is_err());
+
+        let result = dividing(
+            serde_wasm_bindgen::to_value(&JSRect {
+                x: 0.0,
+                y: 0.0,
+                w: 0.0,
+                h: 100.0,
+            })
+            .unwrap(),
+            &[1.0, 1.0],
+            1.0,
+            true,
+            false,
+        );
+        assert!(result.is_err());
+    }
 
     #[wasm_bindgen_test]
     fn test_basis() {


### PR DESCRIPTION
## Summary

The `dividing()` WASM API accepted negative or zero width/height values that passed JSON deserialization successfully (they are valid `f32` values), then silently produced geometrically invalid output — negative coordinates returned as `Ok(_)`. Callers received no error signal.

This PR adds a geometric validity check at the WASM trust boundary immediately after deserialization: if `rect.w <= 0.0` or `rect.h <= 0.0`, the function returns `Err("rect.w and rect.h must be positive")`.

## Changes

- `src/wasm_binding.rs`: guard added after JSON parse, before `Rectangle::new`
- `src/wasm_binding.rs`: three `wasm_bindgen_test` cases for negative w, negative h, and zero w

## Verification

- `cargo test`: 40 tests pass
- `cargo clippy`: no warnings
- `cargo fmt`: no changes

## Trade-offs

The check validates dimensions at the WASM boundary only. A separate existing finding (`audit-invalid-rect-state-constructors-001`) tracks the deeper design gap — that `Rectangle::new` itself has no type-level constraint on non-negative dimensions. That finding is out of scope here.
