### PR TITLE
Move VerticalDividingHelper to rectangle to break circular module dependency

### DIFF
--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -4,8 +4,8 @@ use crate::area::Area;
 use crate::aspect_ratio::AspectRatio;
 use crate::axis::{Axis, SizeForAxis};
 use crate::component::Component;
-use crate::dividing::VerticalDividingHelper;
 use crate::point::{Edge, Point};
+use crate::rectangle::VerticalDividingHelper;
 use crate::rectangle::{Rectangle, RectangleSize};
 use crate::rotate::QuarterRotation;
 

--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -3,7 +3,7 @@ use num_traits::{Float, Num, NumAssignOps, NumOps};
 use crate::{
     area::Area,
     axis::{Axis, SizeForAxis},
-    rectangle::RectangleSize,
+    rectangle::{RectangleSize, VerticalDividingHelper},
     rotate::QuarterRotation,
     weight::normalize_weights,
 };
@@ -170,12 +170,6 @@ pub trait Dividing<T> {
             .map(|r| r.rotate_counter_clockwise())
             .collect()
     }
-}
-
-pub(crate) trait VerticalDividingHelper<T> {
-    fn divide_vertical_helper(&self, x: T) -> (Self, Self)
-    where
-        Self: Sized;
 }
 
 impl<T, U> Dividing<T> for U

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,9 +1,14 @@
 use crate::area::Area;
 use crate::aspect_ratio::AspectRatio;
 use crate::axis::{Axis, SizeForAxis};
-use crate::dividing::VerticalDividingHelper;
 use crate::rotate::QuarterRotation;
 use num_traits::{Float, Num, NumAssignOps, NumOps};
+
+pub(crate) trait VerticalDividingHelper<T> {
+    fn divide_vertical_helper(&self, x: T) -> (Self, Self)
+    where
+        Self: Sized;
+}
 /// rectangle in 2D space with a width and height
 
 #[derive(Debug, PartialEq, Clone, Copy)]


### PR DESCRIPTION
## Summary

`dividing.rs` and `rectangle.rs` had a mutual import cycle:
- `dividing.rs` imported `RectangleSize` from `rectangle`
- `rectangle.rs` imported `VerticalDividingHelper` from `dividing`

This is a layer inversion: `rectangle` is the primitive data model and should sit below `dividing` (the algorithm layer), but the cycle made the dependency bidirectional.

## Change

Move `VerticalDividingHelper` from `dividing.rs` to `rectangle.rs`.

`VerticalDividingHelper` describes how a rectangle splits itself vertically — it is a natural extension of the rectangle abstraction, not an implementation detail of the dividing algorithm. Moving it to `rectangle.rs` establishes a clear one-way dependency:

```
dividing  →  rectangle  (was: dividing ↔ rectangle)
```

`axis_aligned_rectangle.rs` is updated to import `VerticalDividingHelper` from `rectangle` instead of `dividing`.

## Affected files

- `src/rectangle.rs`: added `VerticalDividingHelper` trait definition
- `src/dividing.rs`: removed `VerticalDividingHelper` definition; imports it from `rectangle`
- `src/axis_aligned_rectangle.rs`: updated import path for `VerticalDividingHelper`

## Verification

- `cargo test`: 40 tests pass
- `cargo fmt --all -- --check`: no diff
- `cargo clippy -- -D warnings`: no warnings
- `cargo clippy --all-targets --all-features`: no warnings
