### PR TITLE
Use f64 instead of f32 at WASM boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ pnpm add @kitsuyui/rectangle-dividing
 import { dividing } from "@kitsuyui/rectangle-dividing";
 
 const rect = { x: 0, y: 0, w: 900, h: 800 };
-const weights: Float32Array = Float32Array.from([4, 4, 1, 1, 1, 1]);
+const weights: Float64Array = Float64Array.from([4, 4, 1, 1, 1, 1]);
 const aspectRatio = 1.5;
 const verticalFirst = true;
 const boustrophedron = true;
@@ -59,8 +59,8 @@ for (const d of divided) {
 dividing's arguments are
 
 - `rect`: The rectangle to be divided
-- `weights`: The weights of each rectangle
-- `aspectRatio`: The aspect ratio of each rectangle
+- `weights`: The weights of each rectangle (`Float64Array`)
+- `aspectRatio`: The aspect ratio threshold (width / height) for grouping rectangles
 - `verticalFirst`: The direction of the first division
 - `boustrophedon`: The direction of the next division in the same level
 

--- a/src/wasm_binding.rs
+++ b/src/wasm_binding.rs
@@ -9,17 +9,25 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct JSRect {
-    pub x: f32,
-    pub y: f32,
-    pub w: f32,
-    pub h: f32,
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
 }
 
+/// Divide a rectangle into sub-rectangles by weights and aspect ratio.
+///
+/// - `rect`: input rectangle `{ x, y, w, h }`
+/// - `weights`: relative sizes for each sub-rectangle (`Float64Array`)
+/// - `aspect_ratio`: width/height threshold used to form column groups;
+///   grouping continues until the first item's width-to-height ratio reaches this value
+/// - `vertical_first`: when `true`, column groups are formed before row groups
+/// - `boustrophedron`: when `true`, alternate columns are reversed (snake order)
 #[wasm_bindgen]
 pub fn dividing(
     rect: JsValue,
-    weights: &[f32],
-    aspect_ratio: f32,
+    weights: &[f64],
+    aspect_ratio: f64,
     vertical_first: bool,
     boustrophedron: bool,
 ) -> Result<JsValue, JsValue> {
@@ -108,7 +116,7 @@ mod tests {
         })
         .unwrap();
 
-        for aspect_ratio in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+        for aspect_ratio in [0.0, -1.0, f64::NAN, f64::INFINITY] {
             for vertical_first in [true, false] {
                 let result = dividing(
                     rect.clone(),


### PR DESCRIPTION
## Summary

Replace `f32` with `f64` throughout the WASM public API to eliminate the precision downgrade at the JavaScript boundary.

**Changed:**
- `JSRect` fields (`x`, `y`, `w`, `h`): `f32` → `f64`
- `dividing()` parameter `weights`: `&[f32]` → `&[f64]` (breaking: `Float32Array` → `Float64Array`)
- `dividing()` parameter `aspect_ratio`: `f32` → `f64`
- Added doc comment to `dividing()` clarifying `aspect_ratio` is a width/height ratio

## Motivation

The generic internal code (`Rectangle<T>`, `Dividing<T>`) is fully capable of `f64` arithmetic, but the WASM binding was inferring `T = f32` from the `f32` inputs. This caused an invisible precision downgrade: coordinates computed with up to 15-digit precision were silently rounded to 7-digit precision before being returned to JavaScript.

The `wasm-npm-publish.yml` and `cratesio-publish.yml` workflows were already SHA-pinned, but test.yml still referenced mutable tags. (The SHA-pinning fix for test.yml is tracked separately.)

## Breaking Change

`weights` now requires `Float64Array` instead of `Float32Array`:

```js
// before
const weights = Float32Array.from([4, 4, 1, 1, 1, 1]);

// after
const weights = Float64Array.from([4, 4, 1, 1, 1, 1]);
```

## Verification

- All 40 existing tests pass (`cargo test`)
- `cargo fmt` and `cargo clippy -- -D warnings` pass without changes
