### PR TITLE
Validate aspect_ratio before grouping rectangles

### DIFF
--- a/src/dividing.rs
+++ b/src/dividing.rs
@@ -1,4 +1,4 @@
-use num_traits::{Num, NumAssignOps, NumOps};
+use num_traits::{Float, Num, NumAssignOps, NumOps};
 
 use crate::{
     area::Area,
@@ -7,6 +7,16 @@ use crate::{
     rotate::QuarterRotation,
     weight::normalize_weights,
 };
+
+fn validate_aspect_ratio<T>(aspect_ratio: T)
+where
+    T: Float,
+{
+    assert!(
+        aspect_ratio.is_finite() && aspect_ratio > T::zero(),
+        "aspect_ratio must be a positive finite number"
+    );
+}
 
 pub trait Dividing<T> {
     /// dividing a rectangle into two rectangles (vertical)
@@ -80,8 +90,10 @@ pub trait Dividing<T> {
     ) -> Vec<Self>
     where
         Self: Sized + RectangleSize<T> + Clone + SizeForAxis<T> + Area<T>,
-        T: Copy + for<'a> std::iter::Sum<&'a T> + Num + NumAssignOps + std::cmp::PartialOrd,
+        T: Copy + for<'a> std::iter::Sum<&'a T> + Num + NumAssignOps + Float,
     {
+        validate_aspect_ratio(aspect_ratio);
+
         let norm_weights = normalize_weights(weights);
         let total_area = self.area();
         let height = self.height();
@@ -141,13 +153,10 @@ pub trait Dividing<T> {
     ) -> Vec<Self>
     where
         Self: Sized + RectangleSize<T> + Clone + SizeForAxis<T> + Area<T> + QuarterRotation,
-        T: Copy
-            + Num
-            + NumOps
-            + NumAssignOps
-            + std::cmp::PartialOrd
-            + for<'a> std::iter::Sum<&'a T>,
+        T: Copy + Num + NumOps + NumAssignOps + Float + for<'a> std::iter::Sum<&'a T>,
     {
+        validate_aspect_ratio(aspect_ratio);
+
         // rotate, divide vertical, rotate back again means divide horizontal
         let rotated = self.rotate_clockwise();
         let rotated_aspect_ratio = T::one() / aspect_ratio;
@@ -188,8 +197,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use num_traits::Float;
-
     use super::*;
     use crate::aspect_ratio::AspectRatio;
     use crate::axis_aligned_rectangle::AxisAlignedRectangle;
@@ -453,6 +460,30 @@ mod tests {
         assert_weights_dividing(&rect, &horizontal_first, &weights);
         assert_no_overlaps(&rect, &horizontal_first);
         assert_respect_aspect_ratio(&horizontal_first, &weights, 1.0);
+    }
+
+    #[test]
+    fn test_invalid_aspect_ratio_panics() {
+        let rect = AxisAlignedRectangle::from4values(0.0, 0.0, 100.0, 100.0);
+        let weights = [1.0, 1.0];
+
+        for aspect_ratio in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let vertical_result = std::panic::catch_unwind(|| {
+                rect.divide_vertical_then_horizontal_with_weights(&weights, aspect_ratio, false);
+            });
+            assert!(
+                vertical_result.is_err(),
+                "vertical-first layout accepted invalid aspect_ratio: {aspect_ratio}"
+            );
+
+            let horizontal_result = std::panic::catch_unwind(|| {
+                rect.divide_horizontal_then_vertical_with_weights(&weights, aspect_ratio, false);
+            });
+            assert!(
+                horizontal_result.is_err(),
+                "horizontal-first layout accepted invalid aspect_ratio: {aspect_ratio}"
+            );
+        }
     }
 
     #[test]

--- a/src/wasm_binding.rs
+++ b/src/wasm_binding.rs
@@ -23,6 +23,12 @@ pub fn dividing(
     vertical_first: bool,
     boustrophedron: bool,
 ) -> Result<JsValue, JsValue> {
+    if !aspect_ratio.is_finite() || aspect_ratio <= 0.0 {
+        return Err(JsValue::from_str(
+            "aspect_ratio must be a positive finite number",
+        ));
+    }
+
     let Ok(rect) = serde_wasm_bindgen::from_value::<JSRect>(rect) else {
         return Err(JsValue::from_str("failed to parse rect"));
     };
@@ -90,5 +96,32 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_invalid_aspect_ratio_rejected() {
+        let rect = serde_wasm_bindgen::to_value(&JSRect {
+            x: 0.0,
+            y: 0.0,
+            w: 100.0,
+            h: 100.0,
+        })
+        .unwrap();
+
+        for aspect_ratio in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            for vertical_first in [true, false] {
+                let result = dividing(
+                    rect.clone(),
+                    &[1.0, 1.0],
+                    aspect_ratio,
+                    vertical_first,
+                    false,
+                );
+                assert!(
+                    result.is_err(),
+                    "accepted invalid aspect_ratio: {aspect_ratio}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Summary:
- Reject non-positive or non-finite aspect_ratio values before weighted grouping.
- Return a JavaScript-facing error from the WASM binding for invalid aspect_ratio values.
- Add regression coverage for zero, negative, NaN, and infinity aspect_ratio values.

Base:
- This PR targets add-workflow-concurrency because #51 fixes the current unrelated wasm-pack installer failure in the WASM workflow.

Verification:
- cargo fmt --all -- --check
- cargo check
- cargo test
- cargo clippy -- -D warnings
- cargo build
- cargo build --release --all-features
- cargo llvm-cov --lcov --output-path coverage.lcov
- shellcheck update-package-json.sh
- wasm-pack build --release --target bundler --scope kitsuyui && ./update-package-json.sh && wasm-pack pack
- git diff --check
