### PR TITLE
Limit weights input length in WASM dividing() API

### DIFF
--- a/src/wasm_binding.rs
+++ b/src/wasm_binding.rs
@@ -6,6 +6,8 @@ use crate::rectangle::{Rectangle, RectangleSize};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+const MAX_WEIGHTS_LEN: usize = 65536;
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct JSRect {
     pub x: f64,
@@ -34,6 +36,10 @@ pub fn dividing(
         return Err(JsValue::from_str(
             "aspect_ratio must be a positive finite number",
         ));
+    }
+
+    if weights.len() > MAX_WEIGHTS_LEN {
+        return Err(JsValue::from_str("weights length exceeds maximum"));
     }
 
     let Ok(rect) = serde_wasm_bindgen::from_value::<JSRect>(rect) else {
@@ -118,6 +124,20 @@ mod tests {
             false,
         );
         assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_weights_too_long_rejected() {
+        let rect = serde_wasm_bindgen::to_value(&JSRect {
+            x: 0.0,
+            y: 0.0,
+            w: 100.0,
+            h: 100.0,
+        })
+        .unwrap();
+        let weights = vec![1.0_f64; MAX_WEIGHTS_LEN + 1];
+        let result = dividing(rect, &weights, 1.0, true, false);
+        assert!(result.is_err(), "oversized weights should be rejected");
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

- Reject `weights` slices longer than `MAX_WEIGHTS_LEN` (65 536) in the WASM `dividing()` API.
- Return a JavaScript-facing `Err` immediately, before any heap allocation occurs.

## Why

`dividing()` allocates heap memory proportional to `weights.len()` in three places:
`normalize_weights` allocates a `Vec<f32>` of the same length, the layout function
builds a `Vec<AxisAlignedRectangle>` with one entry per weight, and
`serde_wasm_bindgen::to_value` serializes that Vec into a `JsValue`.
A caller can pass an arbitrarily large `Float32Array` from JavaScript; there is no
limit enforced at the WASM boundary. With 1 M elements each `AxisAlignedRectangle`
takes ~48 bytes, so a single call can allocate ~48 MB of WASM linear memory.

The chosen limit of 65 536 accommodates any realistic layout scenario while capping
worst-case allocation per call at roughly 3 MB.

## Verification

- `cargo fmt --all -- --check` — no formatting changes needed
- `cargo check` — compiles cleanly
- `cargo test` — 40/40 tests pass
- `cargo clippy -- -D warnings` — no warnings

A new `wasm_bindgen_test` confirms that inputs longer than `MAX_WEIGHTS_LEN` return `Err`.

## Trade-offs

The limit is enforced at the WASM boundary only; pure Rust callers of the `Dividing`
trait methods remain unbounded. Moving the guard into the trait methods would add a
`Float` bound on all internal generic impls and is disproportionate to this single
public-API constraint.
