### PR TITLE
fix: restrict wasm_binding to pub(crate) to clarify it is not a library API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,5 @@ pub mod point;
 pub mod rectangle;
 pub(crate) mod rotate;
 pub(crate) mod vector;
-pub mod wasm_binding;
+pub(crate) mod wasm_binding;
 pub(crate) mod weight;

--- a/src/wasm_binding.rs
+++ b/src/wasm_binding.rs
@@ -4,7 +4,6 @@ use crate::dividing::Dividing;
 use crate::point::Point;
 use crate::rectangle::{Rectangle, RectangleSize};
 use serde::{Deserialize, Serialize};
-use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
## Summary

`src/wasm_binding.rs` is a JavaScript/WASM adapter that uses `wasm_bindgen`, `JsValue`, and `serde_wasm_bindgen`. It has no utility outside a WASM environment, yet `lib.rs` declares it as `pub mod wasm_binding`, making it appear to be a public Rust library module alongside domain modules (`dividing`, `rectangle`, `axis`, etc.).

This PR restricts the module visibility to `pub(crate)` so it is clearly not part of the Rust library's public API. The WASM exports themselves are unaffected — `#[wasm_bindgen]` operates at the function level and does not depend on the Rust module being `pub`.

## Changes

- `src/lib.rs`: `pub mod wasm_binding` → `pub(crate) mod wasm_binding`
- `src/wasm_binding.rs`: remove redundant bare `use serde_wasm_bindgen;` import (`clippy::single_component_path_imports`)

## Verification

- `cargo check`, `cargo test` (40 tests pass), `cargo fmt --check`, `cargo clippy -- -D warnings` all pass
- WASM exports are not affected; the `#[wasm_bindgen]` attribute on `pub fn dividing(...)` inside the module remains unchanged

## Trade-offs

- The Rust crate's public surface shrinks: `use rust_rectangle_dividing::wasm_binding::...` is no longer valid from external crates. In practice, the module is only useful in WASM environments and was never intended for Rust callers.
