### PR TITLE
Fix tempfile leak in inplace: add EXIT trap, remove dead rm

### DIFF
--- a/update-package-json.sh
+++ b/update-package-json.sh
@@ -6,10 +6,11 @@ inplace() {
   shift
   local tmp
   tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmp'" EXIT
   echo "Running: $*"
   "$@" < "$file" > "$tmp"
   mv "$tmp" "$file"
-  rm -f "$tmp"
 }
 
 main() {


### PR DESCRIPTION
## Problem

The `inplace` function in `update-package-json.sh` creates a temp file via `mktemp` but does not clean it up when an inner command fails.

With `set -euo pipefail` active, a `jq` error causes the script to exit immediately, leaving the temp file in `/tmp`. Over time (e.g. across repeated CI runs), these leaked files accumulate.

Additionally, the `rm -f "$tmp"` on the line after `mv "$tmp" "$file"` is dead code: `mv` already moves the file to the destination, so that path no longer exists when `rm` is called.

## Fix

Add `trap "rm -f '$tmp'" EXIT` immediately after `mktemp`. This registers a cleanup handler that runs regardless of whether the script exits normally or due to an error. The `$tmp` variable is expanded at trap-set time (intentional — we want the actual path captured), so it correctly removes the specific temp file created in this call. Remove the unreachable `rm -f "$tmp"`.

## Verification

- `shellcheck update-package-json.sh` — no warnings
- `cargo test` — 40 tests pass
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --all -- --check` — clean
