### PR TITLE
Reject negative width/height in Rectangle and AxisAlignedRectangle constructors

### DIFF
--- a/src/axis_aligned_rectangle.rs
+++ b/src/axis_aligned_rectangle.rs
@@ -101,7 +101,7 @@ where
 
 impl<T> AxisAlignedRectangle<T>
 where
-    T: Copy + Num + NumAssignOps + NumOps,
+    T: Copy + Num + NumAssignOps + NumOps + PartialOrd,
 {
     /// Create a new axis aligned rectangle
     pub fn new(point: &Point<T>, rectangle: &Rectangle<T>) -> Self {
@@ -241,7 +241,7 @@ where
 /// Rotate an axis aligned rectangle by 90 degrees
 impl<T> QuarterRotation for AxisAlignedRectangle<T>
 where
-    T: Copy + Num + NumAssignOps,
+    T: Copy + Num + NumAssignOps + PartialOrd,
 {
     fn rotate_clockwise(&self) -> Self {
         Self::from4values(self.y(), self.x(), self.height(), self.width())
@@ -250,7 +250,7 @@ where
 
 impl<T> VerticalDividingHelper<T> for AxisAlignedRectangle<T>
 where
-    T: Copy + Num + NumAssignOps + NumOps,
+    T: Copy + Num + NumAssignOps + NumOps + PartialOrd,
 {
     /// dividing a rectangle into two rectangles (vertical)
     fn divide_vertical_helper(&self, x: T) -> (AxisAlignedRectangle<T>, AxisAlignedRectangle<T>) {
@@ -428,5 +428,17 @@ mod tests {
         let r = AxisAlignedRectangle::from_two_point(&p, &p);
         assert_eq!(r.origin(), p);
         assert_eq!(r.rect(), Rectangle::new(0.0_f64, 0.0_f64));
+    }
+
+    #[test]
+    #[should_panic(expected = "width must be non-negative")]
+    fn test_from4values_rejects_negative_width() {
+        AxisAlignedRectangle::from4values(0, 0, -10, 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "height must be non-negative")]
+    fn test_from4values_rejects_negative_height() {
+        AxisAlignedRectangle::from4values(0, 0, 10, -5);
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -73,9 +73,11 @@ where
 /// A rectangle in 2D space constructor
 impl<T> Rectangle<T>
 where
-    T: Copy + Num + NumAssignOps + NumOps,
+    T: Copy + Num + NumAssignOps + NumOps + PartialOrd,
 {
     pub fn new(width: T, height: T) -> Self {
+        assert!(width >= T::zero(), "width must be non-negative");
+        assert!(height >= T::zero(), "height must be non-negative");
         Self { width, height }
     }
 }
@@ -95,7 +97,7 @@ where
 
 impl<T> VerticalDividingHelper<T> for Rectangle<T>
 where
-    T: Copy + Num + NumAssignOps + NumOps,
+    T: Copy + Num + NumAssignOps + NumOps + PartialOrd,
 {
     /// dividing a rectangle into two rectangles (vertical)
     fn divide_vertical_helper(&self, x: T) -> (Rectangle<T>, Rectangle<T>) {
@@ -229,5 +231,17 @@ mod tests {
         let rotated_twice = rect.rotate_clockwise().rotate_clockwise();
         assert_rect_has_same_component_is_equal(rect, &rotated_twice);
         assert_eq!(rotated_twice, *rect);
+    }
+
+    #[test]
+    #[should_panic(expected = "width must be non-negative")]
+    fn test_new_rejects_negative_width() {
+        Rectangle::new(-1, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "height must be non-negative")]
+    fn test_new_rejects_negative_height() {
+        Rectangle::new(3, -1);
     }
 }


### PR DESCRIPTION
## Problem

`Rectangle<T>` and `AxisAlignedRectangle<T>` constructors accepted negative width and height values without any validation. The `T: Num` trait bound alone does not exclude negative values, so `Rectangle::new(-5, 3)` compiled and created a geometrically invalid state silently.

Downstream methods produce incorrect results for negative dimensions:
- `area()` returns a positive value when both dimensions are negative (negative × negative = positive)
- `aspect_ratio()` returns a negative ratio
- `includes()` / `encloses()` behave incorrectly when `min_x > max_x`
- `divide_vertical_helper` can chain-produce additional negative-width rectangles when `x > self.width`

## Fix

Add `PartialOrd` to the trait bound on `Rectangle::new()` and assert non-negative width and height at construction time. Cascade `PartialOrd` to `VerticalDividingHelper` and `QuarterRotation` impls that transitively call `new()`.

Changed files:
- `src/rectangle.rs`: Add `+ PartialOrd` to constructor impl, add `assert!` guards, add same bound to `VerticalDividingHelper` impl
- `src/axis_aligned_rectangle.rs`: Add `+ PartialOrd` to `new`/`from4values` impl block, `QuarterRotation` impl, and `VerticalDividingHelper` impl

## Trade-offs

- `PartialOrd` is now required for callers of `Rectangle::new()`. All standard numeric types (`i8`–`i128`, `u*`, `f32`, `f64`) satisfy this bound. Complex numbers do not, but are not geometrically meaningful as rectangle dimensions.
- Violations now panic at the point of construction instead of silently propagating. This follows Rust convention for invariant violations (similar to index out-of-bounds).

## Verification

- `cargo test` — 44 tests pass (40 existing + 4 new panic tests)
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --all -- --check` — clean
- `cargo check` — clean
