### PR TITLE
Add CHANGELOG and RELEASING with migration policy for boustrophedron rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+As a pre-1.0 project (currently 0.x), breaking changes may occur between minor versions.
+See [RELEASING.md](RELEASING.md) for the release process and migration guidance.
+
+## [Unreleased]
+
+## [0.1.4] - 2024-07-19
+
+### Changed
+
+- Overhaul: updated `package.json` to enhance npm compatibility
+- Updated WASM target to `bundler` for wider npm ecosystem compatibility
+- README updated with npm install instructions
+
+### Fixed
+
+- Fixed CI coverage reporting condition
+
+## [0.1.3] - 2023-11-10
+
+### Changed
+
+- Updated WASM build target to `bundler`
+
+## [0.1.2] - 2023-11-10
+
+### Fixed
+
+- Minor fixes and version bump
+
+## [0.1.1] - 2023-11-10
+
+### Fixed
+
+- Fixed npm publish workflow
+
+## [0.1.0] - 2023-11-10
+
+### Added
+
+- Initial release
+- WASM bindings for rectangle dividing algorithm
+- Published to crates.io and npm (`@kitsuyui/rectangle-dividing`)
+- Core `dividing()` function with `rect`, `weights`, `aspect_ratio`, `vertical_first`, and `boustrophedron` parameters
+
+## Known Issues
+
+### `boustrophedron` parameter name typo (tracked separately)
+
+The WASM `dividing()` function exposes a parameter named `boustrophedron`, which is a
+misspelling of the correct term `boustrophedon` (alternating direction, like ox-turning
+in ancient writing). The internal Rust implementation uses the correct spelling.
+
+Because the WASM API is positional (not named), JavaScript callers are not affected by
+the parameter name itself. However, documentation and any named bindings that reference
+this parameter use the misspelled form.
+
+This will be corrected in a future release. See [RELEASING.md](RELEASING.md) for the
+planned migration approach.
+
+[Unreleased]: https://github.com/kitsuyui/rust-rectangle-dividing/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/kitsuyui/rust-rectangle-dividing/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/kitsuyui/rust-rectangle-dividing/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/kitsuyui/rust-rectangle-dividing/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/kitsuyui/rust-rectangle-dividing/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/kitsuyui/rust-rectangle-dividing/releases/tag/v0.1.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,41 @@
+# Releasing
+
+## Release Process
+
+1. Update `version` in `Cargo.toml`
+2. Run `cargo build` and `cargo test` to verify
+3. Update `CHANGELOG.md`: move items from `[Unreleased]` to a new versioned section with the release date
+4. Commit: `Bump version to X.Y.Z`
+5. Push and open a PR; wait for CI to pass
+6. Merge and tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+7. GitHub Actions will publish to crates.io and npm automatically
+
+## Versioning Policy
+
+This project follows [Semantic Versioning](https://semver.org/). While the version is
+0.x (pre-1.0), breaking changes to the public API may occur in minor version bumps.
+Breaking changes will always be documented in `CHANGELOG.md`.
+
+## Breaking Changes
+
+When making a breaking change:
+
+1. Add a `### Breaking` section in the `[Unreleased]` block in `CHANGELOG.md`
+2. Describe the old behavior, the new behavior, and a migration path
+3. If a transition period is needed, introduce the new API alongside the old one and
+   mark the old one as deprecated before removing it in a subsequent release
+
+## Known Upcoming Breaking Change: `boustrophedron` → `boustrophedon` rename
+
+The WASM `dividing()` function has a parameter named `boustrophedron` (line 24 of
+`src/wasm_binding.rs`). The correct English term is `boustrophedon`. The internal
+Rust implementation (`src/dividing.rs`) already uses the correct spelling.
+
+**Impact**: The WASM API is positional, so JavaScript callers passing the argument
+by position are not affected. However, any code that relies on the Rust parameter
+name (e.g. via `wasm-bindgen` named argument features, documentation generators,
+or typed bindings) would break on rename.
+
+**Planned fix**: The rename will happen in a future minor version bump. The
+`CHANGELOG.md` will record the version in which this is fixed. No deprecation
+shim is planned; callers should update call sites when upgrading past that version.


### PR DESCRIPTION
## Summary

This repo publishes to both crates.io and npm but has no CHANGELOG, no release
process document, and no migration guidance for known upcoming breaking changes.
This PR adds both.

## Changes

- **`CHANGELOG.md`**: documents version history for v0.1.0–v0.1.4 using
  [Keep a Changelog](https://keepachangelog.com/) format, and includes a
  "Known Issues" section that records the `boustrophedron` parameter-name typo
  (correct term: `boustrophedon`) as a documented upcoming fix.

- **`RELEASING.md`**: documents the release process (version bump, CHANGELOG update,
  tag and publish) and the versioning policy (0.x = breaking changes allowed in minor
  bumps, always documented). Includes a dedicated section for the `boustrophedron` →
  `boustrophedon` rename: impact scope, why it is low-risk for positional callers, and
  the planned approach (rename in a future minor version bump, no deprecation shim).

## Verification

- `cargo fmt` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 40 tests pass

## Trade-offs

The structural approach (CHANGELOG + RELEASING) was chosen over adding only a
CHANGELOG (surface), because the finding specifically concerns the absence of a
migration policy for the known `boustrophedron` typo. A CHANGELOG alone would not
address that gap. A full API versioning redesign (design approach) is out of scope
for this finding.
