### PR TITLE
fix: remove wasm-pack from dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ wasm-bindgen = "0.2"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-wasm-pack = "0.14.0"


### PR DESCRIPTION
## Summary

Remove `wasm-pack` from `[dev-dependencies]` in `Cargo.toml`.

`wasm-pack` is a CLI tool, not a Rust library. Declaring it as a Cargo
dev-dependency causes every `cargo test` (and related commands) to compile
its full transitive closure — including openssl bindings, an HTTP client,
and many other unrelated crates — adding significant overhead to CI builds
and unnecessarily expanding the `cargo audit` / `cargo deny` scope.

`wasm-pack` is already installed in CI via `taiki-e/install-action` in
`.github/workflows/wasm-npm-publish.yml`, so no CI change is needed.

## Impact

- `cargo test` no longer builds wasm-pack's large dependency graph
- `cargo audit` / `cargo deny` scope reduced to only genuinely used crates
- No behavior change: wasm-pack is still installed in CI for the wasm build workflow

## Verification

`cargo test` passes (40 tests). `cargo fmt --check` and `cargo clippy` clean.
