### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ dividing's arguments are
 
 If the weights sum to zero, the weights are treated as equal weights.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # License
 
 MIT

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to run the same checks as CI locally (pre-commit and pre-push hooks)
- Document the setup in `README.md` under a new `## Development` section
- CI workflows are left completely unchanged

## Changes

- **`lefthook.yml`** — new file; defines two hook stages:
  - `pre-commit`: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
  - `pre-push`: the above plus `cargo test`
  All commands match the exact flags used in `.github/workflows/test.yml`.
- **`README.md`** — adds a `## Development` section (inserted before `# License`) explaining how to install and use the hooks.

## Verification

All mirrored checks were verified to pass on the current codebase before committing:

- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — 45 tests passed, 0 failed

The pre-commit hook (fmt + clippy) fired during the commit and passed.
The pre-push hook (fmt + clippy + test) fired during `git push` and passed.

## Notes

- Requires [lefthook](https://lefthook.dev/) on the developer's PATH (`lefthook install` activates the hooks).
- Requires `cargo` (Rust toolchain) to be installed.
- No CI files were modified.
