### PR TITLE
fix: remove --allow-dirty from cargo publish workflow

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: publish (dry-run)
         if: github.event_name == 'release' && github.event.release.prerelease
-        run: cargo publish --dry-run --allow-dirty
+        run: cargo publish --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: publish
         if: github.event_name == 'release' && !github.event.release.prerelease
-        run: cargo publish --allow-dirty
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Remove `--allow-dirty` from both `cargo publish --dry-run` and
`cargo publish` in `.github/workflows/cratesio-publish.yml`.

## Why

The `--allow-dirty` flag bypasses Cargo's built-in safety check that
prevents uncommitted or untracked files from being included in a
published crate. The CI runner starts from a clean checkout, so the
flag was not needed and was silently masking the safety mechanism.

Removing it means Cargo will reject a publish attempt if the working
tree is not clean — which is the correct default for reproducible
releases.

## Changes

- `.github/workflows/cratesio-publish.yml`: remove `--allow-dirty`
  from the dry-run step and the publish step
