### PR TITLE
ci: add cargo audit security workflow and SECURITY.md

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security audit
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via GitHub's private security advisory:
+https://github.com/kitsuyui/rust-rectangle-dividing/security/advisories/new
+
+Do not open a public issue for security vulnerabilities. We will acknowledge
+reports within 7 days and aim to address confirmed vulnerabilities within 90 days.


### PR DESCRIPTION
## Summary

Add `cargo audit` to CI and a `SECURITY.md` with a responsible disclosure link.

- New `.github/workflows/security.yml`: runs `cargo audit` on push to main, PRs, and weekly on Sunday
- New `SECURITY.md`: directs reporters to GitHub's private security advisory

## Why

The CI had no check for known vulnerabilities in dependencies (RustSec Advisory Database). Without `cargo audit`, a dependency with a published CVE could remain in use undetected. `SECURITY.md` provides a clear disclosure path for external researchers — without it, reporters have no option but to open a public issue.

## Changes

- `.github/workflows/security.yml`: dedicated security audit workflow with weekly schedule
- `SECURITY.md`: minimal security policy pointing to GitHub private advisory

## Verification

The new `security.yml` workflow will run on this PR's CI.

## Trade-offs

- `cargo install cargo-audit --locked` adds build time; subsequent runs use the `Swatinem/rust-cache` cache.
- A weekly scheduled run catches newly published advisories even when the codebase is quiet.
